### PR TITLE
Fixes to enable build of slash in macOS

### DIFF
--- a/wscript
+++ b/wscript
@@ -5,9 +5,10 @@ APPNAME = 'slash'
 VERSION = '0.1.0'
 
 def options(ctx):
-    pass
+    ctx.load('compiler_c')
 
 def configure(ctx):
+    ctx.load('compiler_c')
     ctx.check(header_name='termios.h', features='c cprogram', mandatory=False)
 
 def build(ctx):
@@ -16,3 +17,7 @@ def build(ctx):
         source   = 'src/slash.c',
         includes = 'include',
         export_includes = 'include')
+    ctx.program(
+        target   = APPNAME + 'test',
+        source   = 'src/slash.c test/slashtest.c',
+        includes = 'include')


### PR DESCRIPTION
 I wanted to play with slash on my Mac, and needed to fix the build / write some custom code for macOS to make it link and run properly. More technical details are in the commit message.

@jledet @johandc I've verified the code also builds under gcc-4.9 in Linux under Docker, but I didn't get a chance do functional testing in Linux, so you might want to verify `slashtest` runs as expected?