### PR TITLE
slash: ensure entire command name matches

### DIFF
--- a/src/slash.c
+++ b/src/slash.c
@@ -367,6 +367,10 @@ slash_command_find(struct slash *slash, char *line, size_t linelen, char **args)
 			if (strncmp(token, cur->name, tokenlen) != 0)
 				continue;
 
+			/* Ensure entire command name matches */
+			if (strlen(cur->name) != tokenlen)
+				continue;
+
 			/* Skip if privileged command in non-privileged mode */
 			if (!slash->privileged &&
 			    (cur->flags & SLASH_FLAG_PRIVILEGED))

--- a/test/test.c
+++ b/test/test.c
@@ -128,6 +128,17 @@ static void slash_test_context_command(void **state)
 	assert_int_equal(ret, 0);
 }
 
+static void slash_test_partial(void **state)
+{
+	struct slash *slash = *state;
+
+	int ret;
+	char *cmd = "e"; /* Partial match on builtin echo */
+
+	ret = slash_execute(slash, cmd);
+	assert_int_equal(ret, -ENOENT);
+}
+
 static int setup(void **state)
 {
 	struct slash *slash = slash_create(LINE_SIZE, HISTORY_SIZE);
@@ -152,6 +163,7 @@ int main(void)
 		cmocka_unit_test(slash_test_sub_command),
 		cmocka_unit_test(slash_test_privileged_command),
 		cmocka_unit_test(slash_test_context_command),
+		cmocka_unit_test(slash_test_partial),
 	};
 
 	return cmocka_run_group_tests(tests, setup, teardown);


### PR DESCRIPTION
The token is not guaranteed to be zero-terminated so we have to use strncmp, but this also matches on partial commands. Add an additional check on the token length to avoid this.